### PR TITLE
Task/48 gnome dconf updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added ZSH installation, custom zshrc template
 - Added Yarn (and Nodejs)
 - GNOME Preferences - set "attach-modal-dialogs" to False
+- GNOME Preferences - set Desktop Window Management "focus-mode" to sloppy
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added GNOME theme, icon, cursor installation
 - Added ZSH installation, custom zshrc template
 - Added Yarn (and Nodejs)
+- GNOME Preferences - set "attach-modal-dialogs" to False
 
 ### Removed
 

--- a/roles/gnome-preferences/tasks/main.yml
+++ b/roles/gnome-preferences/tasks/main.yml
@@ -74,6 +74,12 @@
     value: "true"
     state: present
 
+- name: GNOME Preferences - Shell - Attach Modeal Dialogues
+  dconf:
+    key: "/org/gnome/shell/overrides/attach-modal-dialogs"
+    value: "false"
+    state: present
+
 # Shell Overrides
 - name: GNOME Preferences - Workspaces Only on Primary
   dconf:

--- a/roles/gnome-preferences/tasks/main.yml
+++ b/roles/gnome-preferences/tasks/main.yml
@@ -49,6 +49,12 @@
     value: "'appmenu:minimize,maximize,close'"
     state: present
 
+- name: GNOME Preferences - Focus Mode
+  dconf:
+    key: "/org/gnome/desktop/wm/preferences/focus-mode"
+    value: "'sloppy'"
+    state: present
+
 # Nautilus (File Manager) Usability
 - name: GNOME Preferences - Nautilus - Default Zoom Level
   dconf:


### PR DESCRIPTION
Implements https://github.com/iancleary/personal-ansible/issues/48

Also adds GNOME Preferences: wm/preferences/focus-mode set to 'sloppy'