### PR TITLE
CI: removed '. /etc/profile'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,6 @@ jobs:
         - make docker
         - make zsh
         - make yarn
-        - . /etc/profile
         - vue --version
         - gridsome --version
 


### PR DESCRIPTION
The sourcing of path after installing yarn globals now occurs within the `make yarn` role